### PR TITLE
Changed valuer to return string instead of byte[]

### DIFF
--- a/null_test.go
+++ b/null_test.go
@@ -218,9 +218,9 @@ func TestNullWeek_Value(t *testing.T) {
 		Expected interface{}
 		Error    bool
 	}{
-		{Week: NullWeek{Week: Week{year: 1, week: 1}, Valid: true}, Expected: []byte("0001-W01")},
-		{Week: NullWeek{Week: Week{year: 2001, week: 22}, Valid: true}, Expected: []byte("2001-W22")},
-		{Week: NullWeek{Week: Week{year: 9999, week: 52}, Valid: true}, Expected: []byte("9999-W52")},
+		{Week: NullWeek{Week: Week{year: 1, week: 1}, Valid: true}, Expected: "0001-W01"},
+		{Week: NullWeek{Week: Week{year: 2001, week: 22}, Valid: true}, Expected: "2001-W22"},
+		{Week: NullWeek{Week: Week{year: 9999, week: 52}, Valid: true}, Expected: "9999-W52"},
 		{Week: NullWeek{}, Expected: nil},
 		{Week: NullWeek{Week: Week{year: -100, week: 22}, Valid: true}, Error: true},
 	}

--- a/week.go
+++ b/week.go
@@ -189,7 +189,7 @@ func (w Week) Value() (driver.Value, error) {
 		return nil, errors.Wrap(err, "unable to create value")
 	}
 
-	return driver.Value(text), nil
+	return driver.Value(string(text)), nil
 }
 
 // Scan implements scanner for Week.

--- a/week_test.go
+++ b/week_test.go
@@ -420,7 +420,7 @@ func TestWeek_Value(t *testing.T) {
 			assert.Error(t, err)
 		} else {
 			require.NoError(t, err)
-			assert.Equal(t, []byte(tt.Expected), result)
+			assert.Equal(t, tt.Expected, result)
 		}
 	}
 }


### PR DESCRIPTION
In order for type to correctly work with go-pg and db Valuer interface should return string type.
Now Value in DB is mapped like"\x323032312d573036" instead of something like "2021-W12".
This change will allow correct mapping so we can use go-week without manual .String() calls.

